### PR TITLE
Rearrange parameters to use default vals

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
+* * *
+
+**GitHub Issue**: (link)
+
+* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
+
+# What does this Pull Request do?
+A brief description of what the intended result of the PR will be and/or what problem it solves.
+
+# How should this be tested?
+
+A description of what steps someone could take to:
+* Reproduce the problem you are fixing (if applicable)
+* Test that the Pull Request does what is intended.
+* Please be as detailed as possible.
+* Good testing instructions help get your PR completed faster.
+
+# Test coverage
+Yes/No: Are changes in this pull-request covered by:
+- unit tests?
+- integration tests?
+
+# Interested parties
+Tag (@ mention) interested parties

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a shared library for resuable pipelines
 // default values: slackChannel = "lts-jenkins-notifications"
 
 def endpoints = []
-ltsBasicPipeline.call("<imageName>", "<stackName>", "<projName>", "<slackChannel>", "<intTestPort>", endpoints) 
+ltsBasicPipeline.call("<imageName>", "<stackName>", "<projName>", "<intTestPort>", endpoints, "<slackChannel>") 
 ```
 
 NOTE: don't exclude the '_' at the end of the import line

--- a/vars/ltsBasicPipeline.groovy
+++ b/vars/ltsBasicPipeline.groovy
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-def call(String imageName, String stackName, String projName, String slackChannel = "lts-jenkins-notifications", String intTestPort, List intTestEndpoints) {
+def call(String imageName, String stackName, String projName, String intTestPort, List intTestEndpoints, String slackChannel = "lts-jenkins-notifications") {
   pipeline {
 
   agent any


### PR DESCRIPTION
**Rearrange parameters to use default vals**
* * *

**GitHub Issue**: n/a

# What does this Pull Request do?
Rearranges parameters so when the last param is left off, the default value will be used

# How should this be tested?

test on librarycloud_transformer trail branch

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n/a
- integration tests? n/a

# Interested parties
@mac0373 
